### PR TITLE
Add model selection to PromptInterface and clean up SupportPage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,18 +68,18 @@ function App() {
                 <Route path="usage" element={<UsagePage />} />
                 <Route path="cost" element={<CostPage />} />
                 <Route path="profile" element={<ProfilePage />} />
-                <Route path="support" element={<SupportPage />} />
+                {/* <Route path="support" element={<SupportPage />} /> */}
                 <Route path="prompt" element={<PromptInterface />} />
                 <Route path="documentation" element={<Documentation />} />
               </Route>
-              <Route path="/ecommerce/*" element={
+              {/* <Route path="/ecommerce/*" element={
                 <CartProvider>
                   <EcommerceLayout>
                     <Ecommerce />
                   </EcommerceLayout>
                 </CartProvider>
               }>
-              </Route>
+              </Route> */}
             </Routes>
           </Router>
         </AuthProvider>

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -56,9 +56,9 @@ export const DashboardLayout = () => {
     { text: 'Cost', icon: <CostIcon />, path: '/cost' },
     // { text: 'Billing', icon: <BillingIcon />, path: '/billing' },
     // { text: 'Profile', icon: <PersonIcon />, path: '/profile' },
-    { text: 'Chatbot', icon: <ChatIcon />, path: '/support' },
+    // { text: 'Chatbot', icon: <ChatIcon />, path: '/support' },
     { text: 'Documentation', icon: <FeedbackIcon />, path: '/documentation' },
-    { text: 'Ecommerce', icon: <EcommerceIcon />, path: '/ecommerce' }
+    // { text: 'Ecommerce', icon: <EcommerceIcon />, path: '/ecommerce' }
   ];
 
   const drawer = (

--- a/src/pages/SupportPage.tsx
+++ b/src/pages/SupportPage.tsx
@@ -360,7 +360,7 @@ export const SupportPage = () => {
               mt: 1,
               width: 'fit-content'
             }}>
-              🤖 You are chatting with an LLM model: <Typography variant="body1" sx={{ fontWeight: 'bold' }}>InternVL2_5-1B</Typography>
+              🤖 You are chatting with an LLM model: <Typography variant="body1" sx={{ fontWeight: 'bold' }}>InternVL2_5-1B-MPO</Typography>
             </Typography>
           </Box>
           <Button


### PR DESCRIPTION
Introduce a model selection feature in the PromptInterface, allowing users to choose from available models. Comment out unused routes and dashboard items related to support and ecommerce for better code clarity.